### PR TITLE
feat: add '--no-output-file' for '--list' subcommand

### DIFF
--- a/src/payload_dumper/__init__.py
+++ b/src/payload_dumper/__init__.py
@@ -40,6 +40,11 @@ def main():
         help="list partitions in the payload file",
     )
     parser.add_argument(
+        "--no-output",
+        action="store_true",
+        help="change '--list' behavior to only print partition names, no create files and directory in current work directory.",
+    )
+    parser.add_argument(
         "--metadata",
         action="store_true",
         help="extract and display metadata file from the payload",
@@ -47,8 +52,9 @@ def main():
     parser.add_argument("--header", action="append", nargs=2)
     args = parser.parse_args()
 
+    output_files = (not args.no_output) if args.list else True
     # Check for --out directory exists
-    if not os.path.exists(args.out):
+    if (not os.path.exists(args.out)) and output_files:
         os.makedirs(args.out)
 
     payload_file = args.payloadfile
@@ -70,6 +76,7 @@ def main():
         workers=args.workers,
         list_partitions=args.list,
         extract_metadata=args.metadata,
+        output_files=output_files
     )
 
     dumper.run()

--- a/src/payload_dumper/__init__.py
+++ b/src/payload_dumper/__init__.py
@@ -40,7 +40,7 @@ def main():
         help="list partitions in the payload file",
     )
     parser.add_argument(
-        "--no-output",
+        "--no-output-file",
         action="store_true",
         help="change '--list' behavior to only print partition names, no create files and directory in current work directory.",
     )
@@ -52,7 +52,7 @@ def main():
     parser.add_argument("--header", action="append", nargs=2)
     args = parser.parse_args()
 
-    output_files = (not args.no_output) if args.list else True
+    output_files = (not args.no_output_file) if args.list else True
     # Check for --out directory exists
     if (not os.path.exists(args.out)) and output_files:
         os.makedirs(args.out)

--- a/src/payload_dumper/dumper.py
+++ b/src/payload_dumper/dumper.py
@@ -81,7 +81,7 @@ def bsdf2_read_patch(fi):
 
 class Dumper:
     def __init__(
-        self, payloadfile, out, diff=None, old=None, images="", workers=cpu_count(), list_partitions=False, extract_metadata=False
+        self, payloadfile, out, diff=None, old=None, images="", workers=cpu_count(), list_partitions=False, extract_metadata=False, output_files = True
     ):
         self.payloadfile: mtio.MTIOBase = payloadfile
         self.manager = get_manager()
@@ -92,7 +92,8 @@ class Dumper:
         self.workers = workers
         self.list_partitions = list_partitions
         self.extract_metadata = extract_metadata
-
+        self.output_files = output_files
+        
         if self.extract_metadata:
             self.extract_and_display_metadata()
         else:
@@ -329,14 +330,15 @@ class Dumper:
         
         # Output to JSON file
         output_file = os.path.join(self.out, "partitions_info.json")
-        with open(output_file, "w") as f:
-            json.dump(partitions_info, f, indent=4)
+        if(self.output_files):
+            with open(output_file, "w") as f:
+                json.dump(partitions_info, f, indent=4)
 
         # Print to console in a compact format
         readable_info = '\n'.join(f"{info['partition_name']}({info['size_readable']})" for info in partitions_info)
         print(f'Total {len(partitions_info)} partitions')
         print(readable_info)
-        print(f"\nPartition information saved to {output_file}")
+        if(self.output_files): print(f"\nPartition information saved to {output_file}")
 
     def extract_and_display_metadata(self):
         # Try to extract and display the metadata file from the zip


### PR DESCRIPTION
Currently, use '--list' subcommand always creates a files in `output/`, I add a flag '--no-output-file' to disable it.